### PR TITLE
Allow :any IN expected hash as value

### DIFF
--- a/lib/savon/mock/expectation.rb
+++ b/lib/savon/mock/expectation.rb
@@ -54,8 +54,18 @@ module Savon
     end
 
     def verify_message!
+      def equals_except_any(msg_expected, msg_real)
+        return true if msg_expected == msg_real
+        return false if (msg_expected.nil? || msg_real.nil?) # If both are nil has returned true
+        msg_expected.each do |key, expected_value|
+          next if (expected_value == :any &&  msg_real.include?(key))
+          return false if expected_value != msg_real[key]
+        end
+        return true
+      end
+      
       return if @expected[:message] == :any
-      unless @expected[:message] == @actual[:message]
+      unless equals_except_any(@expected[:message], @actual[:message])
         expected_message = "  with this message: #{@expected[:message].inspect}" if @expected[:message]
         expected_message ||= "  with no message."
 

--- a/spec/savon/mock_spec.rb
+++ b/spec/savon/mock_spec.rb
@@ -23,6 +23,17 @@ describe "Savon's mock interface" do
     expect(response.http.body).to eq("<fixture/>")
   end
 
+  it "can verify a request with any parameters and return a fixture response" do
+    message = { :username => "luke", :password => :any }
+    savon.expects(:authenticate).with(:message => message).returns("<fixture/>")
+
+    response = new_client.call(:authenticate) do
+      message(:username => "luke", :password => "secret")
+    end
+
+    expect(response.http.body).to eq("<fixture/>")
+  end
+
   it "accepts a Hash to specify the response code, headers and body" do
     soap_fault = Fixture.response(:soap_fault)
     response = { :code => 500, :headers => { "X-Result" => "invalid" }, :body => soap_fault }


### PR DESCRIPTION
This to accomodate for example random (or hard to mock) values in the message.

In our case this was needed when the request/message needed a random RequestID.

In theory we would be able to mock this random value, on the other hand we needed to introduce a mocking library in our test sutie just for this.
